### PR TITLE
🛡️ Sentinel: Fix hardcoded JWT secrets and add mandatory startup checks

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+dist
 # Keep environment variables out of version control
 .env
 

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -92,13 +92,13 @@ const generateTokens = (userId: string) => {
   
   const accessToken = jwt.sign(
     payload, 
-    process.env.JWT_SECRET || 'fallback_secret',
+    process.env.JWT_SECRET!,
     { expiresIn: ACCESS_TOKEN_EXPIRES_IN as NonNullable<SignOptions['expiresIn']> }
   );
 
   const refreshToken = jwt.sign(
     payload,
-    process.env.JWT_REFRESH_SECRET || 'fallback_refresh_secret',
+    process.env.JWT_REFRESH_SECRET!,
     { expiresIn: REFRESH_TOKEN_EXPIRES_IN as NonNullable<SignOptions['expiresIn']> }
   );
 
@@ -381,7 +381,7 @@ export const refreshToken = asyncHandler(async (req: Request, res: Response) => 
   try {
     const decoded = jwt.verify(
       token, 
-      process.env.JWT_REFRESH_SECRET || 'fallback_refresh_secret'
+      process.env.JWT_REFRESH_SECRET!
     ) as any;
 
     const user = await prisma.user.findUnique({

--- a/backend/src/controllers/groupController.ts
+++ b/backend/src/controllers/groupController.ts
@@ -81,7 +81,7 @@ const normalizeInviteEmail = (email?: string) => {
   return email.trim().toLowerCase();
 };
 
-const getInviteTokenSecret = () => process.env.JWT_SECRET || 'your-secret-key';
+const getInviteTokenSecret = () => process.env.JWT_SECRET!;
 
 const getInviteLinkBaseUrl = () => {
   const raw = process.env.FRONTEND_URL || process.env.CLIENT_URL || 'http://localhost';

--- a/backend/src/controllers/linkedinController.ts
+++ b/backend/src/controllers/linkedinController.ts
@@ -64,7 +64,7 @@ const setOAuthStatus = (userId: string, status: Omit<LinkedInOAuthImportStatus, 
   });
 };
 
-const getJwtSecret = () => process.env.JWT_SECRET || 'linkedin-oauth-fallback-secret';
+const getJwtSecret = () => process.env.JWT_SECRET!;
 
 const normalizeLinkedInProfileUrl = (input?: string | null): string | undefined => {
   if (!input || typeof input !== 'string') return undefined;

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -21,7 +21,7 @@ export const authMiddleware = async (req: AuthRequest, res: Response, next: Next
       return;
     }
 
-    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'your-secret-key') as { userId: string };
+    const decoded = jwt.verify(token, process.env.JWT_SECRET!) as { userId: string };
 
     const user = await prisma.user.findUnique({
       where: { id: decoded.userId },

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -53,6 +53,14 @@ if (!fs.existsSync(uploadsDir)) {
 // Phase 1 - Enhanced app initialization
 const initializeApp = async () => {
   console.log('🚀 Starting Alma Connect Sphere Backend...');
+
+  // Security check: Ensure critical environment variables are set
+  if (!process.env.JWT_SECRET || !process.env.JWT_REFRESH_SECRET) {
+    console.error('❌ CRITICAL ERROR: JWT_SECRET and JWT_REFRESH_SECRET must be defined in environment variables.');
+    console.error('Shutting down due to missing security configuration.');
+    process.exit(1);
+  }
+
   console.log('📋 Phase 1: Core Authentication & Security + Profiles');
   await ensureDefaultSuperAdmins();
   console.log('✅ Application initialized successfully');


### PR DESCRIPTION
This PR addresses a critical security vulnerability where hardcoded fallback strings were being used as JWT secrets if the corresponding environment variables were missing.

Key changes:
1. Removed all instances of 'fallback_secret', 'fallback_refresh_secret', 'your-secret-key', and 'linkedin-oauth-fallback-secret' used as JWT secrets.
2. Updated `backend/src/server.ts` to include a mandatory check for `JWT_SECRET` and `JWT_REFRESH_SECRET` during the application initialization phase. The server will now log a critical error and exit if these are not defined.
3. Updated `backend/.gitignore` to exclude the `dist` directory.

These changes ensure that the application always runs with secure, environment-specific secrets and fails fast if the configuration is insecure.

---
*PR created automatically by Jules for task [17097164042934666200](https://jules.google.com/task/17097164042934666200) started by @futurist-raghav*