### PR TITLE
🛡️ Sentinel: Fix Path Traversal in file serving

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-13 - Path Traversal in File Serving
+**Vulnerability:** The `/api/uploads/:filename` endpoint was vulnerable to path traversal because it directly used the `filename` parameter from the URL in a `path.join()` call without sanitization.
+**Learning:** Even when serving files from a dedicated uploads directory, parameters must be sanitized using `path.basename()` to prevent directory traversal attacks (e.g., `../../package.json`).
+**Prevention:** Always use `path.basename()` on user-provided filenames before using them to construct file system paths.

--- a/backend/src/controllers/uploadController.ts
+++ b/backend/src/controllers/uploadController.ts
@@ -217,7 +217,7 @@ export const uploadMultipleFiles = asyncHandler(async (req: AuthRequest, res: Re
 
 // Serve uploaded files
 export const serveFile = asyncHandler(async (req: Request, res: Response): Promise<void> => {
-  const { filename } = req.params;
+  const filename = req.params.filename as string;
   
   if (!filename) {
     res.status(400).json({
@@ -227,7 +227,9 @@ export const serveFile = asyncHandler(async (req: Request, res: Response): Promi
     return;
   }
 
-  const filePath = path.join(__dirname, '../../uploads', filename);
+  // Sanitize filename to prevent path traversal
+  const sanitizedFilename = path.basename(filename);
+  const filePath = path.join(__dirname, '../../uploads', sanitizedFilename);
 
   if (!fs.existsSync(filePath)) {
     res.status(404).json({


### PR DESCRIPTION
Fixed a path traversal vulnerability in the file serving controller by sanitizing the filename input. Added a security journal entry to document the fix.

---
*PR created automatically by Jules for task [12190461128982981643](https://jules.google.com/task/12190461128982981643) started by @futurist-raghav*