### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Mass Assignment in User Profile Update

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-05-16 - [Mass Assignment in User Profile Update]
+**Vulnerability:** The `updateProfile` function in `userController.ts` spreads `req.body` directly into a Prisma update call.
+**Learning:** This allows users to modify sensitive fields like their own `role`, `status`, or `isVerified` status by including them in the request body.
+**Prevention:** Always use a whitelist of allowed fields when updating records from user-provided input.

--- a/backend/src/controllers/userController.ts
+++ b/backend/src/controllers/userController.ts
@@ -823,9 +823,24 @@ export const updateProfile = asyncHandler(async (req: AuthRequest, res: Response
     return;
   }
 
+  // Security: Whitelist allowed fields to prevent mass assignment (e.g., updating role or status)
+  const allowedFields = [
+    'name', 'firstName', 'lastName', 'bio', 'headline', 'city', 'country',
+    'company', 'jobTitle', 'contactEmail', 'contactPhone', 'linkedInProfile',
+    'location', 'isAvailableAsMentor', 'notificationSettings', 'privacySettings',
+    'experiences', 'educations', 'skills', 'interests'
+  ];
+
+  const updateData: Record<string, any> = {};
+  for (const field of allowedFields) {
+    if (req.body[field] !== undefined) {
+      updateData[field] = req.body[field];
+    }
+  }
+
   const profile = await prisma.user.update({
     where: { id },
-    data: { ...req.body }
+    data: updateData
   });
 
   res.status(200).json({ success: true, data: serializeUser(profile) });


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Mass Assignment in User Profile Update
🎯 Impact: Users could escalate their own privileges or modify sensitive account status by including fields like `role` or `isVerified` in their profile update requests.
🔧 Fix: Replaced the direct spread of `req.body` with a strictly defined whitelist of allowed fields in `updateProfile`.
✅ Verification: Manually verified the implementation against the Prisma schema and the validation logic defined in `backend/src/routes/users.ts`. confirmed that sensitive fields are no longer included in the update data.

---
*PR created automatically by Jules for task [3122080375017339266](https://jules.google.com/task/3122080375017339266) started by @futurist-raghav*