### PR TITLE
🛡️ Sentinel: Fix [CRITICAL] Mass Assignment in profile update

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel Security Journal 🛡️
+
+## 2026-05-17 - [CRITICAL] Mass Assignment in Profile Update
+**Vulnerability:** The `updateProfile` function in `userController.ts` used `{ ...req.body }` directly in a Prisma `update` call. This allowed any authenticated user to modify sensitive fields like `role`, `status`, and `isVerified` by including them in the request body.
+**Learning:** Using spread operators on request bodies for database updates is extremely dangerous as it bypasses intended access controls and allows users to modify internal state.
+**Prevention:** Always use a strict whitelist of allowed fields when updating records from user-provided input.

--- a/backend/src/controllers/userController.ts
+++ b/backend/src/controllers/userController.ts
@@ -823,9 +823,24 @@ export const updateProfile = asyncHandler(async (req: AuthRequest, res: Response
     return;
   }
 
+  // Security: Use a strict whitelist for profile updates to prevent mass assignment
+  const allowedFields = [
+    'name', 'firstName', 'lastName', 'bio', 'headline', 'city', 'country',
+    'company', 'jobTitle', 'contactEmail', 'contactPhone', 'linkedInProfile',
+    'location', 'profileImage', 'isAvailableAsMentor', 'notificationSettings',
+    'privacySettings', 'experiences', 'educations', 'skills', 'interests'
+  ];
+
+  const updateData: Record<string, any> = {};
+  for (const field of allowedFields) {
+    if (req.body[field] !== undefined) {
+      updateData[field] = req.body[field];
+    }
+  }
+
   const profile = await prisma.user.update({
     where: { id },
-    data: { ...req.body }
+    data: updateData
   });
 
   res.status(200).json({ success: true, data: serializeUser(profile) });


### PR DESCRIPTION
This PR fixes a critical mass assignment vulnerability in the user profile update endpoint. By using a strict whitelist of allowed fields, we prevent users from modifying sensitive internal attributes like their role or verification status.

Changes:
- Modified `backend/src/controllers/userController.ts`: `updateProfile` now only accepts a specific set of safe fields.
- Created/Updated `.jules/sentinel.md`: Documented the vulnerability and prevention pattern.

---
*PR created automatically by Jules for task [10199715750340608404](https://jules.google.com/task/10199715750340608404) started by @futurist-raghav*