### PR TITLE
🛡️ Sentinel: Fix path traversal in upload controller

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - [Path Traversal in File Serving]
+**Vulnerability:** The `serveFile` controller in `uploadController.ts` was directly using a user-provided `filename` parameter from the URL to construct a file path using `path.join()`. This allowed an attacker to use sequences like `../../` to access files outside the intended `uploads/` directory.
+**Learning:** Even when using `path.join()` with a base directory, user-controlled input must be sanitized if it's used as a path segment. `path.join` does not automatically resolve or block traversal sequences.
+**Prevention:** Always wrap user-provided filenames or path segments in `path.basename()` before joining them to a base path. This strips any directory information and keeps only the filename.

--- a/backend/src/controllers/uploadController.ts
+++ b/backend/src/controllers/uploadController.ts
@@ -227,7 +227,9 @@ export const serveFile = asyncHandler(async (req: Request, res: Response): Promi
     return;
   }
 
-  const filePath = path.join(__dirname, '../../uploads', filename);
+  // Sanitize filename to prevent path traversal
+  const safeFilename = path.basename(filename);
+  const filePath = path.join(__dirname, '../../uploads', safeFilename);
 
   if (!fs.existsSync(filePath)) {
     res.status(404).json({


### PR DESCRIPTION
Identified and fixed a path traversal vulnerability in the backend's file serving logic. The `serveFile` controller in `uploadController.ts` was directly joining user-provided `filename` parameters with the uploads directory path, enabling attackers to access files outside of the intended directory using `../` sequences. The fix involves sanitizing the input with `path.basename()`. Additionally, cleaned up unrelated build artifacts and dependency lockfile changes to keep the PR focused and safe.

---
*PR created automatically by Jules for task [8777401271164570283](https://jules.google.com/task/8777401271164570283) started by @futurist-raghav*