### PR TITLE
🛡️ Sentinel: [HIGH] Fix mass assignment in user profile update

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-23 - [HIGH] Mass Assignment in User Profile Update
+**Vulnerability:** The `updateProfile` function in `userController.ts` used a spread operator (`...req.body`) directly in the Prisma `update` call, allowing users to modify sensitive fields like `role`, `status`, and `isVerified`.
+**Learning:** This pattern existed because it's a convenient way to implement partial updates, but it fails to enforce boundaries between user-modifiable profile data and system-controlled account metadata.
+**Prevention:** Always use an explicit whitelist of allowed fields when performing database updates from user-provided request bodies. Do not use spread operators or `Object.assign` directly on `req.body` for sensitive models.

--- a/backend/src/controllers/userController.ts
+++ b/backend/src/controllers/userController.ts
@@ -823,9 +823,42 @@ export const updateProfile = asyncHandler(async (req: AuthRequest, res: Response
     return;
   }
 
+  // Security: Use a whitelist of allowed fields to prevent mass assignment
+  // of sensitive fields like role, status, or isVerified.
+  const {
+    name, firstName, lastName, bio, headline, profileImage,
+    city, country, company, jobTitle, contactEmail, contactPhone,
+    linkedInProfile, location, isAvailableAsMentor,
+    notificationSettings, privacySettings,
+    experiences, educations, skills, interests
+  } = req.body;
+
+  const updateData: any = {};
+  if (name !== undefined) updateData.name = name;
+  if (firstName !== undefined) updateData.firstName = firstName;
+  if (lastName !== undefined) updateData.lastName = lastName;
+  if (bio !== undefined) updateData.bio = bio;
+  if (headline !== undefined) updateData.headline = headline;
+  if (profileImage !== undefined) updateData.profileImage = profileImage;
+  if (city !== undefined) updateData.city = city;
+  if (country !== undefined) updateData.country = country;
+  if (company !== undefined) updateData.company = company;
+  if (jobTitle !== undefined) updateData.jobTitle = jobTitle;
+  if (contactEmail !== undefined) updateData.contactEmail = contactEmail;
+  if (contactPhone !== undefined) updateData.contactPhone = contactPhone;
+  if (linkedInProfile !== undefined) updateData.linkedInProfile = linkedInProfile;
+  if (location !== undefined) updateData.location = location;
+  if (isAvailableAsMentor !== undefined) updateData.isAvailableAsMentor = isAvailableAsMentor;
+  if (notificationSettings !== undefined) updateData.notificationSettings = notificationSettings;
+  if (privacySettings !== undefined) updateData.privacySettings = privacySettings;
+  if (experiences !== undefined) updateData.experiences = experiences;
+  if (educations !== undefined) updateData.educations = educations;
+  if (skills !== undefined) updateData.skills = skills;
+  if (interests !== undefined) updateData.interests = interests;
+
   const profile = await prisma.user.update({
     where: { id },
-    data: { ...req.body }
+    data: updateData
   });
 
   res.status(200).json({ success: true, data: serializeUser(profile) });


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix mass assignment in user profile update

The `updateProfile` function in `userController.ts` was using a spread operator (`...req.body`) in the Prisma `update` call. This allowed users to update sensitive fields such as `role`, `status`, and `isVerified`, potentially leading to privilege escalation or unauthorized account changes.

This fix implements a strict whitelist of allowed profile fields:
- name, firstName, lastName
- bio, headline, profileImage
- city, country, company, jobTitle
- contactEmail, contactPhone, linkedInProfile, location
- isAvailableAsMentor
- notificationSettings, privacySettings
- experiences, educations, skills, interests

Non-whitelisted fields in `req.body` are now ignored.

---
*PR created automatically by Jules for task [9551127277103476863](https://jules.google.com/task/9551127277103476863) started by @futurist-raghav*