### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in File Serving

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-14 - Path Traversal in File Serving
+**Vulnerability:** The `serveFile` controller in `uploadController.ts` was directly using the `filename` from request parameters to construct a file path using `path.join()`.
+**Learning:** Even when using `path.join()` with a hardcoded base directory, user-provided filenames containing `..` can escape the intended directory if not sanitized.
+**Prevention:** Always use `path.basename()` on user-provided filenames before using them in path construction to ensure they remain within the target directory.

--- a/backend/src/controllers/uploadController.ts
+++ b/backend/src/controllers/uploadController.ts
@@ -217,7 +217,7 @@ export const uploadMultipleFiles = asyncHandler(async (req: AuthRequest, res: Re
 
 // Serve uploaded files
 export const serveFile = asyncHandler(async (req: Request, res: Response): Promise<void> => {
-  const { filename } = req.params;
+  const filename = typeof req.params.filename === 'string' ? req.params.filename : '';
   
   if (!filename) {
     res.status(400).json({
@@ -227,7 +227,9 @@ export const serveFile = asyncHandler(async (req: Request, res: Response): Promi
     return;
   }
 
-  const filePath = path.join(__dirname, '../../uploads', filename);
+  // Use path.basename to prevent path traversal vulnerabilities
+  const safeFilename = path.basename(filename);
+  const filePath = path.join(__dirname, '../../uploads', safeFilename);
 
   if (!fs.existsSync(filePath)) {
     res.status(404).json({


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Path Traversal in file serving endpoint
🎯 Impact: Attackers could read sensitive files on the server (e.g., .env, system files) by using '..' sequences in the filename parameter.
🔧 Fix: Implemented path.basename() sanitization on the user-provided filename and added a type check.
✅ Verification: Verified using a reproduction script that demonstrated directory escape with the original logic and successful confinement with the fixed logic. Legitimate file access was also verified to still work.

---
*PR created automatically by Jules for task [18036478498996542790](https://jules.google.com/task/18036478498996542790) started by @futurist-raghav*