### PR TITLE
🛡️ Sentinel: Fix mass assignment vulnerability in user profile updates

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,11 @@
+# Sentinel's Journal - Critical Security Learnings
+
+## 2025-05-15 - [Mass Assignment Protection]
+**Vulnerability:** User profile update allowed updating any field in the User model, including roles and account status, by spreading `req.body` into the Prisma update call.
+**Learning:** This is a common pitfall when using modern ORMs like Prisma. Even with frontend validation and API-level validation (like `express-validator`), if the controller doesn't explicitly whitelist fields before passing them to the ORM, an attacker can bypass these checks by sending extra fields in the JSON payload.
+**Prevention:** Always use an explicit whitelist of allowed fields in controllers before passing data to ORM update/create methods.
+
+## 2025-05-15 - [Tool Side Effects]
+**Vulnerability:** Running `npm install` in the backend directory can lead to massive, unintended updates to `package-lock.json`, including major version upgrades (e.g., Express 4 to 5) that may break the application.
+**Learning:** In a legacy or partially updated environment, `npm install` might resolve to the latest versions instead of sticking to the current ones if the lockfile isn't perfectly synced. This can bundle dangerous breaking changes with a small fix.
+**Prevention:** Always review `package-lock.json` changes carefully before committing. Use `git restore` to revert unintended dependency updates if they are not necessary for the task at hand.

--- a/backend/src/controllers/userController.ts
+++ b/backend/src/controllers/userController.ts
@@ -78,6 +78,13 @@ const isAdminRole = (role?: string) => {
 
 const isSuperAdminRole = (role?: string) => normalizeRole(role) === 'SUPER_ADMIN';
 
+const ALLOWED_PROFILE_FIELDS = [
+  'name', 'firstName', 'lastName', 'bio', 'headline', 'profileImage',
+  'city', 'country', 'company', 'jobTitle', 'contactEmail', 'contactPhone',
+  'linkedInProfile', 'location', 'isAvailableAsMentor', 'notificationSettings',
+  'privacySettings', 'experiences', 'educations', 'skills', 'interests'
+];
+
 const hiddenSystemEmails = () => [...getHiddenSystemAccountEmails()];
 
 const notHiddenSystemAccountsFilter = () => ({ notIn: hiddenSystemEmails() });
@@ -823,9 +830,17 @@ export const updateProfile = asyncHandler(async (req: AuthRequest, res: Response
     return;
   }
 
+  // Security: Whitelist fields to prevent mass assignment (e.g. changing role/status)
+  const updateData: Record<string, any> = {};
+  for (const field of ALLOWED_PROFILE_FIELDS) {
+    if (req.body[field] !== undefined) {
+      updateData[field] = req.body[field];
+    }
+  }
+
   const profile = await prisma.user.update({
     where: { id },
-    data: { ...req.body }
+    data: updateData
   });
 
   res.status(200).json({ success: true, data: serializeUser(profile) });


### PR DESCRIPTION
Resolved a mass assignment vulnerability in the updateProfile controller by implementing an explicit whitelist of allowed fields. This prevents users from escalating privileges or modifying sensitive account attributes during profile updates. Whitelisted fields include name, bio, headline, and other public profile data, while protecting internal fields like role and status.

---
*PR created automatically by Jules for task [11388863182000109769](https://jules.google.com/task/11388863182000109769) started by @futurist-raghav*