### PR TITLE
Fix path traversal in uploadController

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-21 - [Path Traversal in uploadController]
+**Vulnerability:** User-provided filename in the `serveFile` function was used directly to construct a file path without sanitization, allowing potential path traversal attacks.
+**Learning:** Even simple file-serving endpoints can be vulnerable if they directly use URL parameters to access the filesystem.
+**Prevention:** Always use `path.basename()` to sanitize user-provided filenames before using them in file path construction, and verify the parameter type.

--- a/backend/src/controllers/uploadController.ts
+++ b/backend/src/controllers/uploadController.ts
@@ -219,7 +219,7 @@ export const uploadMultipleFiles = asyncHandler(async (req: AuthRequest, res: Re
 export const serveFile = asyncHandler(async (req: Request, res: Response): Promise<void> => {
   const { filename } = req.params;
   
-  if (!filename) {
+  if (!filename || typeof filename !== 'string') {
     res.status(400).json({
       success: false,
       message: 'Filename is required'
@@ -227,7 +227,9 @@ export const serveFile = asyncHandler(async (req: Request, res: Response): Promi
     return;
   }
 
-  const filePath = path.join(__dirname, '../../uploads', filename);
+  // Sanitize filename to prevent path traversal
+  const safeFilename = path.basename(filename);
+  const filePath = path.join(__dirname, '../../uploads', safeFilename);
 
   if (!fs.existsSync(filePath)) {
     res.status(404).json({


### PR DESCRIPTION
Implemented path traversal protection in \`backend/src/controllers/uploadController.ts\` by sanitizing the \`filename\` parameter with \`path.basename()\` and ensuring it is a string. This prevents attackers from accessing files outside the intended uploads directory. Verified the fix with a standalone test script. addressed code review feedback by ensuring no unrelated dependency or build artifact changes were included.

---
*PR created automatically by Jules for task [13828447744255830510](https://jules.google.com/task/13828447744255830510) started by @futurist-raghav*