### PR TITLE
🛡️ Sentinel: Fix Mass Assignment in User Profile Update

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - [Mass Assignment in User Profile Update]
+**Vulnerability:** The `updateProfile` function in `userController.ts` used `...req.body` directly in a Prisma `update` call, allowing users to modify sensitive fields like `role`, `status`, or `isVerified`.
+**Learning:** Even when using modern ORMs like Prisma, direct spread of request bodies into database operations remains a common source of mass assignment vulnerabilities. Whitelisting is the most robust defense.
+**Prevention:** Always use an explicit whitelist of allowed fields when performing updates or creations based on user-provided input. Avoid using spread operators (`...req.body`) for database operations.

--- a/backend/src/controllers/userController.ts
+++ b/backend/src/controllers/userController.ts
@@ -823,9 +823,24 @@ export const updateProfile = asyncHandler(async (req: AuthRequest, res: Response
     return;
   }
 
+  // Security: Whitelist allowed fields to prevent mass assignment (e.g. changing role or status)
+  const allowedFields = [
+    'name', 'firstName', 'lastName', 'bio', 'headline', 'profileImage',
+    'city', 'country', 'company', 'jobTitle', 'contactEmail', 'contactPhone',
+    'linkedInProfile', 'location', 'isAvailableAsMentor', 'notificationSettings',
+    'privacySettings', 'experiences', 'educations', 'skills', 'interests'
+  ];
+
+  const updateData: any = {};
+  for (const field of allowedFields) {
+    if (req.body[field] !== undefined) {
+      updateData[field] = req.body[field];
+    }
+  }
+
   const profile = await prisma.user.update({
     where: { id },
-    data: { ...req.body }
+    data: updateData
   });
 
   res.status(200).json({ success: true, data: serializeUser(profile) });


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Mass Assignment in User Profile Update
🎯 Impact: Users could potentially elevate their privileges (e.g., setting role to 'ADMIN') or bypass account restrictions by including sensitive fields in their profile update requests.
🔧 Fix: Replaced direct spread of `req.body` with a strict whitelist of allowed profile fields in `backend/src/controllers/userController.ts`.
✅ Verification: Verified the filtering logic using a standalone test script that confirmed forbidden fields are correctly excluded while allowed fields are preserved.

---
*PR created automatically by Jules for task [13883326211135546192](https://jules.google.com/task/13883326211135546192) started by @futurist-raghav*