### PR TITLE
Fix mass assignment in user profile updates

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-14 - [Fixed Mass Assignment in User Profile Updates]
+**Vulnerability:** The `updateProfile` function in `userController.ts` was using the spread operator `...req.body` directly in the Prisma `update` call, allowing users to potentially modify sensitive internal fields like `role`, `status`, or `isVerified`.
+**Learning:** Over-reliance on request body spreading without explicit filtering is a common source of mass assignment vulnerabilities in Express/Prisma applications.
+**Prevention:** Always use a strict whitelist for fields that can be updated via public API endpoints, especially for user profile and administrative models.

--- a/backend/src/controllers/userController.ts
+++ b/backend/src/controllers/userController.ts
@@ -823,9 +823,24 @@ export const updateProfile = asyncHandler(async (req: AuthRequest, res: Response
     return;
   }
 
+  const allowedFields = [
+    'name', 'firstName', 'lastName', 'bio', 'headline', 'profileImage',
+    'city', 'country', 'company', 'jobTitle', 'contactEmail', 'contactPhone',
+    'linkedInProfile', 'location', 'isAvailableAsMentor',
+    'notificationSettings', 'privacySettings', 'experiences', 'educations',
+    'skills', 'interests'
+  ];
+
+  const updateData: any = {};
+  for (const field of allowedFields) {
+    if (req.body[field] !== undefined) {
+      updateData[field] = req.body[field];
+    }
+  }
+
   const profile = await prisma.user.update({
     where: { id },
-    data: { ...req.body }
+    data: updateData
   });
 
   res.status(200).json({ success: true, data: serializeUser(profile) });


### PR DESCRIPTION
Identified and resolved a mass assignment vulnerability in the `updateProfile` controller within `backend/src/controllers/userController.ts`. The vulnerability allowed authenticated users to potentially overwrite sensitive fields such as their `role` or `status` by including them in the request body of a profile update.

The fix replaces the direct use of `...req.body` with a strict whitelist of permitted profile fields. This ensures that only designated fields can be updated through the public profile endpoint, while sensitive administrative fields remain protected.

Additionally, a security journal entry has been added to `.jules/sentinel.md` to document the finding and prevent future regressions.

---
*PR created automatically by Jules for task [16814396833645589696](https://jules.google.com/task/16814396833645589696) started by @futurist-raghav*