### PR TITLE
Fix Path Traversal in uploadController.ts

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - [Path Traversal in serveFile]
+**Vulnerability:** Path traversal in `serveFile` controller allowed access to arbitrary files by including `../` in the `filename` parameter.
+**Learning:** Using `path.join` with unsanitized user input is a common source of path traversal vulnerabilities.
+**Prevention:** Always sanitize filenames from user input using `path.basename()` to strip directory components before joining with a base path.

--- a/backend/src/controllers/uploadController.ts
+++ b/backend/src/controllers/uploadController.ts
@@ -227,7 +227,9 @@ export const serveFile = asyncHandler(async (req: Request, res: Response): Promi
     return;
   }
 
-  const filePath = path.join(__dirname, '../../uploads', filename);
+  // Sanitize filename to prevent path traversal
+  const safeFilename = path.basename(filename);
+  const filePath = path.join(__dirname, '../../uploads', safeFilename);
 
   if (!fs.existsSync(filePath)) {
     res.status(404).json({


### PR DESCRIPTION
Fixed a critical path traversal vulnerability in the file serving endpoint and added a security journal entry.

---
*PR created automatically by Jules for task [10879730526779043103](https://jules.google.com/task/10879730526779043103) started by @futurist-raghav*