### PR TITLE
🛡️ Sentinel: Fix mass assignment vulnerability in user profile updates

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - [Mass Assignment Protection in User Profile Updates]
+**Vulnerability:** A mass assignment vulnerability existed in the `updateProfile` function of `userController.ts`, where the spread operator (`...req.body`) was used directly in the Prisma `update` call. This allowed authenticated users to potentially overwrite sensitive fields like `role`, `status`, or `isVerified`.
+**Learning:** Using the spread operator on request bodies in database update operations bypasses intended field restrictions and introduces a common security risk where internal state can be manipulated by external input.
+**Prevention:** Always use a strict whitelist or a dedicated DTO (Data Transfer Object) pattern to explicitly pick only the allowed fields from the request body before passing them to database update or create operations.

--- a/backend/src/controllers/userController.ts
+++ b/backend/src/controllers/userController.ts
@@ -823,9 +823,29 @@ export const updateProfile = asyncHandler(async (req: AuthRequest, res: Response
     return;
   }
 
+  // Security: Implement whitelist for profile updates to prevent mass assignment
+  const allowedFields = [
+    'name', 'firstName', 'lastName', 'bio', 'headline', 'city', 'country',
+    'company', 'jobTitle', 'contactEmail', 'contactPhone', 'linkedInProfile',
+    'location', 'isAvailableAsMentor', 'experiences', 'educations', 'skills',
+    'interests'
+  ];
+
+  const updateData: any = {};
+  for (const field of allowedFields) {
+    if (req.body[field] !== undefined) {
+      updateData[field] = req.body[field];
+    }
+  }
+
+  if (Object.keys(updateData).length === 0) {
+    res.status(400).json({ success: false, message: 'No valid fields provided for update' });
+    return;
+  }
+
   const profile = await prisma.user.update({
     where: { id },
-    data: { ...req.body }
+    data: updateData
   });
 
   res.status(200).json({ success: true, data: serializeUser(profile) });


### PR DESCRIPTION
🛡️ Sentinel: Fix mass assignment vulnerability in user profile updates

**🚨 Severity: HIGH**
**💡 Vulnerability:** Mass Assignment (CWE-915)
**🎯 Impact:** Authenticated users could potentially elevate their own privileges or bypass verification status by including restricted fields like `role`, `isVerified`, or `status` in their profile update requests.
**🔧 Fix:** Replaced the insecure spread operator (`...req.body`) with a strict whitelist of allowed fields (`name`, `bio`, `headline`, etc.) in the `updateProfile` function.
**✅ Verification:**
- Targeted type checking confirmed the fix is type-safe.
- Code review verified the implementation follows security best practices.
- Manual inspection of the controller confirms strict field filtering.

---
*PR created automatically by Jules for task [2471678053695687446](https://jules.google.com/task/2471678053695687446) started by @futurist-raghav*