### PR TITLE
🛡️ Sentinel: Fix path traversal in serveFile

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-11 - [Path Traversal in serveFile]
+**Vulnerability:** Path traversal in `backend/src/controllers/uploadController.ts` via the `serveFile` controller allowed unauthorized access to files outside the intended `uploads/` directory by manipulating the `filename` parameter (e.g., using `../../package.json`).
+**Learning:** Using `path.join` with unsanitized user input in file operations is a classic vulnerability. Even if a base directory is provided, `..` segments can "escape" it.
+**Prevention:** Always sanitize user-provided filenames using `path.basename()` and normalize path separators (especially for cross-platform compatibility, e.g., replacing `\` with `/`) before joining them with a base directory. Additionally, ensuring input types (e.g., `typeof filename === 'string'`) prevents unexpected behavior.

--- a/backend/src/controllers/uploadController.ts
+++ b/backend/src/controllers/uploadController.ts
@@ -219,15 +219,17 @@ export const uploadMultipleFiles = asyncHandler(async (req: AuthRequest, res: Re
 export const serveFile = asyncHandler(async (req: Request, res: Response): Promise<void> => {
   const { filename } = req.params;
   
-  if (!filename) {
+  if (!filename || typeof filename !== 'string') {
     res.status(400).json({
       success: false,
-      message: 'Filename is required'
+      message: 'Valid filename is required'
     });
     return;
   }
 
-  const filePath = path.join(__dirname, '../../uploads', filename);
+  // Mitigate path traversal by extracting only the base filename
+  const safeFilename = path.basename(filename.replace(/\\/g, '/'));
+  const filePath = path.join(__dirname, '../../uploads', safeFilename);
 
   if (!fs.existsSync(filePath)) {
     res.status(404).json({


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix path traversal in serveFile

Fixed a critical path traversal vulnerability in the backend file serving logic that allowed unauthorized access to files outside the intended uploads directory. The fix involves sanitizing user-provided filenames using `path.basename()` and ensuring input validity. Also initiated the Sentinel security journal in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [17923052039360852239](https://jules.google.com/task/17923052039360852239) started by @futurist-raghav*