### PR TITLE
🛡️ Sentinel: Fix path traversal in file uploads

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-06-12 - [Path Traversal in File Uploads]
+**Vulnerability:** The `serveFile` controller in `backend/src/controllers/uploadController.ts` was vulnerable to path traversal because it used user-provided `filename` directly in `path.join()` without sanitization.
+**Learning:** Even with a dedicated uploads directory, attackers can use `../` to escape and read sensitive files like `package.json`, `.env`, or source code. `path.basename()` is a simple and effective way to strip directory components.
+**Prevention:** Always sanitize user-provided filenames using `path.basename()` before using them in file system operations. For extra security, ensure the resolved path starts with the intended base directory.

--- a/backend/src/controllers/uploadController.ts
+++ b/backend/src/controllers/uploadController.ts
@@ -219,15 +219,17 @@ export const uploadMultipleFiles = asyncHandler(async (req: AuthRequest, res: Re
 export const serveFile = asyncHandler(async (req: Request, res: Response): Promise<void> => {
   const { filename } = req.params;
   
-  if (!filename) {
+  if (!filename || typeof filename !== 'string') {
     res.status(400).json({
       success: false,
-      message: 'Filename is required'
+      message: 'Valid filename is required'
     });
     return;
   }
 
-  const filePath = path.join(__dirname, '../../uploads', filename);
+  // Sanitize filename to prevent path traversal
+  const safeFilename = path.basename(filename.replace(/\\/g, '/'));
+  const filePath = path.join(__dirname, '../../uploads', safeFilename);
 
   if (!fs.existsSync(filePath)) {
     res.status(404).json({


### PR DESCRIPTION
Identified and fixed a path traversal vulnerability in the file serving endpoint. The `serveFile` function in `backend/src/controllers/uploadController.ts` previously used the `filename` parameter directly in `path.join()`, allowing attackers to access arbitrary files on the server using `../` sequences.

The fix involves:
1. Validating that `filename` is a string.
2. Replacing backslashes with forward slashes for cross-platform consistency.
3. Using `path.basename()` to strip all directory components from the filename, ensuring it remains within the intended `uploads/` directory.

Also initialized a security journal at `.jules/sentinel.md` to document this finding and prevent future occurrences.

---
*PR created automatically by Jules for task [15567606296808250517](https://jules.google.com/task/15567606296808250517) started by @futurist-raghav*