### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in file download

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-13 - [Path Traversal in File Serving]
+**Vulnerability:** The `serveFile` controller was directly using user-provided `filename` parameters in `path.join()`, allowing access to arbitrary files on the server.
+**Learning:** Even with simple Express routing, parameters like `req.params.filename` must be sanitized if used in filesystem operations.
+**Prevention:** Use `path.basename()` and replace backslashes with forward slashes to ensure the resulting filename is constrained to the intended directory.

--- a/backend/src/controllers/uploadController.ts
+++ b/backend/src/controllers/uploadController.ts
@@ -219,7 +219,7 @@ export const uploadMultipleFiles = asyncHandler(async (req: AuthRequest, res: Re
 export const serveFile = asyncHandler(async (req: Request, res: Response): Promise<void> => {
   const { filename } = req.params;
   
-  if (!filename) {
+  if (!filename || typeof filename !== 'string') {
     res.status(400).json({
       success: false,
       message: 'Filename is required'
@@ -227,7 +227,9 @@ export const serveFile = asyncHandler(async (req: Request, res: Response): Promi
     return;
   }
 
-  const filePath = path.join(__dirname, '../../uploads', filename);
+  // Security: Prevent path traversal by extracting only the base filename
+  const safeFilename = path.basename(filename.replace(/\\/g, '/'));
+  const filePath = path.join(__dirname, '../../uploads', safeFilename);
 
   if (!fs.existsSync(filePath)) {
     res.status(404).json({


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Path Traversal
🎯 Impact: Unauthorized access to arbitrary files on the server (e.g., config files, source code).
🔧 Fix: Sanitized the `filename` parameter using `path.basename(filename.replace(/\\/g, '/'))` and added a type check.
✅ Verification: Verified with a standalone Node.js script testing various traversal patterns (`../../`, `..\..\`, etc.) and confirmed resulting paths are constrained to the `uploads/` directory.

---
*PR created automatically by Jules for task [14253398814928521261](https://jules.google.com/task/14253398814928521261) started by @futurist-raghav*