### PR TITLE
🛡️ Sentinel: Fix mass assignment in report creation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-14 - [Mass Assignment in Report Creation]
+**Vulnerability:** The `createReport` controller was using `...req.body` to create new reports, allowing users to potentially set administrative fields like `status` or `adminNotes`.
+**Learning:** Using spread operators on request bodies directly in database create/update calls is a common pattern that leads to mass assignment vulnerabilities when the model contains both user-controlled and system-controlled fields.
+**Prevention:** Always use explicit field whitelisting in controllers. Destructure allowed fields from `req.body` and pass only those to the database layer.

--- a/backend/src/controllers/reportController.ts
+++ b/backend/src/controllers/reportController.ts
@@ -7,10 +7,37 @@ interface AuthRequest extends Request {
 }
 
 export const createReport = asyncHandler(async (req: AuthRequest, res: Response): Promise<void> => {
-  if (!req.user?.id) { res.status(401).json({ message: 'Not authenticated' }); return; }
+  if (!req.user?.id) {
+    res.status(401).json({ message: 'Not authenticated' });
+    return;
+  }
+
+  const {
+    type,
+    description,
+    reason,
+    reportedUserId,
+    reportedPostId,
+    reportedCommentId,
+    reportedGroupId,
+    reportedJobId
+  } = req.body;
+
+  // Mass assignment protection: only allow whitelisted fields
   const report = await prisma.report.create({
-    data: { ...req.body, reportedById: req.user.id }
+    data: {
+      type,
+      description,
+      reason,
+      reportedUserId,
+      reportedPostId,
+      reportedCommentId,
+      reportedGroupId,
+      reportedJobId,
+      reportedById: req.user.id
+    }
   });
+
   res.status(201).json({ success: true, data: report });
 });
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Mass assignment in `createReport` controller.
🎯 Impact: Attackers could set a report's status to 'RESOLVED' or add 'adminNotes' during creation, bypassing the moderation workflow.
🔧 Fix: Implemented explicit field whitelisting in the `createReport` controller.
✅ Verification: Verified with a standalone Node.js script that forbidden fields are ignored. Passed ESLint.

---
*PR created automatically by Jules for task [1193762445657179998](https://jules.google.com/task/1193762445657179998) started by @futurist-raghav*