### PR TITLE
🛡️ Sentinel: Fix mass assignment vulnerability in createGroup

### DIFF
--- a/backend/src/controllers/groupController.ts
+++ b/backend/src/controllers/groupController.ts
@@ -131,11 +131,26 @@ const getNextAdminCandidateId = async (
 };
 
 export const createGroup = asyncHandler(async (req: AuthRequest, res: Response): Promise<void> => {
-  if (!req.user?.id) { res.status(401).json({ message: 'Not authenticated' }); return; }
+  if (!req.user?.id) {
+    res.status(401).json({ message: 'Not authenticated' });
+    return;
+  }
+
+  const { name, description, privacy, category } = req.body;
+
+  // Manual whitelisting to prevent mass assignment of sensitive fields
   const group = await prisma.group.create({
-    data: { ...req.body, creatorId: req.user.id, members: { connect: { id: req.user.id } } },
+    data: {
+      name: String(name || '').trim(),
+      description: String(description || '').trim(),
+      privacy: privacy === 'private' ? 'private' : 'public',
+      category: String(category || 'professional').trim(),
+      creatorId: req.user.id,
+      members: { connect: { id: req.user.id } }
+    },
     include: { creator: true, members: true }
   });
+
   res.status(201).json({ success: true, data: group });
 });
 


### PR DESCRIPTION
This PR addresses a Mass Assignment (Overposting) vulnerability in the `createGroup` endpoint. By explicitly whitelisting the fields extracted from `req.body`, we prevent unauthorized modification of sensitive or internal model fields.

🚨 Severity: HIGH
💡 Vulnerability: Mass Assignment
🎯 Impact: Attackers could potentially overwrite internal fields like `creatorId`, `memberCount`, or `id` during group creation.
🔧 Fix: Implemented manual whitelisting and sanitization of user-provided fields.
✅ Verification: Verified through code review and static analysis. Pre-existing linting and type errors in the controller were noted but are unrelated to this fix.

---
*PR created automatically by Jules for task [570646934452045831](https://jules.google.com/task/570646934452045831) started by @futurist-raghav*