### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in serveFile

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-18 - [Path Traversal in File Serving]
+**Vulnerability:** The `serveFile` endpoint in `uploadController.ts` was directly using the `filename` parameter from the URL to construct a file path, allowing for directory traversal attacks (e.g., `../../package.json`).
+**Learning:** Even with `path.join`, if the last argument is an absolute path or contains traversal sequences like `..`, it can escape the intended directory.
+**Prevention:** Use `path.basename()` to strip any directory components from user-supplied filenames before using them in file system operations. Also, ensure cross-platform compatibility by replacing backslashes with forward slashes before applying `path.basename()`.

--- a/backend/src/controllers/uploadController.ts
+++ b/backend/src/controllers/uploadController.ts
@@ -219,15 +219,17 @@ export const uploadMultipleFiles = asyncHandler(async (req: AuthRequest, res: Re
 export const serveFile = asyncHandler(async (req: Request, res: Response): Promise<void> => {
   const { filename } = req.params;
   
-  if (!filename) {
+  if (!filename || typeof filename !== 'string') {
     res.status(400).json({
       success: false,
-      message: 'Filename is required'
+      message: 'Filename is required and must be a string'
     });
     return;
   }
 
-  const filePath = path.join(__dirname, '../../uploads', filename);
+  // Security: Sanitize filename to prevent path traversal
+  const sanitizedFilename = path.basename(filename.replace(/\\/g, '/'));
+  const filePath = path.join(__dirname, '../../uploads', sanitizedFilename);
 
   if (!fs.existsSync(filePath)) {
     res.status(404).json({


### PR DESCRIPTION
This PR fixes a critical path traversal vulnerability in the file serving endpoint. The `serveFile` controller was directly using the `filename` parameter from the request URL to construct a file path, allowing an attacker to access files outside the `uploads` directory using `..` sequences.

Changes:
- Added `path.basename()` to sanitize the `filename` parameter.
- Added a check to ensure `filename` is a string.
- Replaced backslashes with forward slashes before sanitization to ensure cross-platform consistency.
- Updated the Sentinel security journal with learnings from this fix.

---
*PR created automatically by Jules for task [1731752367315778681](https://jules.google.com/task/1731752367315778681) started by @futurist-raghav*