### PR TITLE
🛡️ Sentinel: [HIGH] Fix mass assignment in report creation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-23 - [Mass Assignment Prevention in Report Creation]
+**Vulnerability:** The `createReport` endpoint in `reportController.ts` used the spread operator (`...req.body`) to create a new report, allowing users to potentially overwrite sensitive fields like `status`, `adminNotes`, or `reviewedById`.
+**Learning:** Spread operators on `req.body` for database creation or update operations are a primary source of mass assignment vulnerabilities, especially when the Prisma model contains both user-controllable and system-managed fields.
+**Prevention:** Always use a strict whitelist for fields extracted from the request body. A mapping loop over an `allowedFields` array is a clean and maintainable way to enforce this.

--- a/backend/src/controllers/reportController.ts
+++ b/backend/src/controllers/reportController.ts
@@ -8,8 +8,28 @@ interface AuthRequest extends Request {
 
 export const createReport = asyncHandler(async (req: AuthRequest, res: Response): Promise<void> => {
   if (!req.user?.id) { res.status(401).json({ message: 'Not authenticated' }); return; }
+
+  const allowedFields = [
+    'type',
+    'description',
+    'reason',
+    'reportedUserId',
+    'reportedPostId',
+    'reportedCommentId',
+    'reportedGroupId',
+    'reportedJobId'
+  ];
+
+  const reportData: any = { reportedById: req.user.id };
+
+  allowedFields.forEach(field => {
+    if (req.body[field] !== undefined) {
+      reportData[field] = req.body[field];
+    }
+  });
+
   const report = await prisma.report.create({
-    data: { ...req.body, reportedById: req.user.id }
+    data: reportData
   });
   res.status(201).json({ success: true, data: report });
 });


### PR DESCRIPTION
### 🛡️ Sentinel: [HIGH] Fix mass assignment in report creation

🚨 **Severity:** HIGH
💡 **Vulnerability:** Mass assignment in \`createReport\` controller
🎯 **Impact:** Users could potentially set administrative fields like \`status\`, \`adminNotes\`, or \`reviewedById\` when creating a report, potentially bypassing moderation workflows.
🔧 **Fix:** Implemented field whitelisting for \`createReport\` input in \`backend/src/controllers/reportController.ts\`.
✅ **Verification:** Verified with manual code review, targeted TypeScript check (\`npx tsc\`), and ESLint.

Documentation updated in \`.jules/sentinel.md\`.

---
*PR created automatically by Jules for task [16151701472325369523](https://jules.google.com/task/16151701472325369523) started by @futurist-raghav*