### PR TITLE
🛡️ Sentinel: Fix path traversal in upload controller

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-22 - [Fix] Path Traversal in File Upload Controller
+**Vulnerability:** Unsanitized user input in `serveFile` controller allowed arbitrary file reading via `filename` parameter.
+**Learning:** Using `path.join` with raw request parameters without sanitization is a classic path traversal risk.
+**Prevention:** Always use `path.basename()` to strip directory information from user-provided filenames and verify that the resolved path is indeed a file using `fs.statSync(filePath).isFile()`. Additionally, replace backslashes with forward slashes before calling `path.basename()` to handle Windows-style path traversal attempts on Linux servers.

--- a/backend/src/controllers/uploadController.ts
+++ b/backend/src/controllers/uploadController.ts
@@ -218,18 +218,22 @@ export const uploadMultipleFiles = asyncHandler(async (req: AuthRequest, res: Re
 // Serve uploaded files
 export const serveFile = asyncHandler(async (req: Request, res: Response): Promise<void> => {
   const { filename } = req.params;
-  
-  if (!filename) {
+
+  if (!filename || typeof filename !== 'string') {
     res.status(400).json({
       success: false,
-      message: 'Filename is required'
+      message: 'Valid filename is required'
     });
     return;
   }
 
-  const filePath = path.join(__dirname, '../../uploads', filename);
+  // Sanitize filename to prevent path traversal vulnerabilities.
+  // path.basename() ensures we only get the filename portion, and replace() handles Windows-style paths.
+  const sanitizedFilename = path.basename(filename.replace(/\\/g, '/'));
+  const filePath = path.join(__dirname, '../../uploads', sanitizedFilename);
 
-  if (!fs.existsSync(filePath)) {
+  // Verify that the file exists and is indeed a file (not a directory)
+  if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
     res.status(404).json({
       success: false,
       message: 'File not found'


### PR DESCRIPTION
Fixed a critical path traversal vulnerability in the backend's file upload controller by sanitizing the filename parameter.

---
*PR created automatically by Jules for task [5131218623127444564](https://jules.google.com/task/5131218623127444564) started by @futurist-raghav*