### PR TITLE
🛡️ Sentinel: Fix Mass Assignment vulnerability in updateProfile

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-25 - [Mass Assignment in updateProfile]
+**Vulnerability:** Mass assignment in the `updateProfile` controller allowed any authenticated user to potentially overwrite sensitive database fields (like `role` or `isVerified`) by including them in the request body.
+**Learning:** The application relied on the spread operator (`{ ...req.body }`) for Prisma updates in several controllers, providing no input filtering.
+**Prevention:** Always use a whitelist to extract only permitted fields from the request body before passing data to database update functions.

--- a/backend/src/controllers/userController.ts
+++ b/backend/src/controllers/userController.ts
@@ -823,9 +823,24 @@ export const updateProfile = asyncHandler(async (req: AuthRequest, res: Response
     return;
   }
 
+  // Define whitelisted fields to prevent mass assignment vulnerabilities
+  const allowedFields = [
+    'name', 'firstName', 'lastName', 'bio', 'headline',
+    'city', 'country', 'company', 'jobTitle', 'contactEmail',
+    'contactPhone', 'linkedInProfile', 'location', 'isAvailableAsMentor',
+    'profileImage', 'experiences', 'educations', 'skills', 'interests'
+  ];
+
+  const updateData: any = {};
+  for (const field of allowedFields) {
+    if (req.body[field] !== undefined) {
+      updateData[field] = req.body[field];
+    }
+  }
+
   const profile = await prisma.user.update({
     where: { id },
-    data: { ...req.body }
+    data: updateData
   });
 
   res.status(200).json({ success: true, data: serializeUser(profile) });


### PR DESCRIPTION
This PR addresses a Mass Assignment vulnerability in the user profile update endpoint. By whitelisting allowed fields, we prevent users from modifying sensitive administrative fields through the request body.

---
*PR created automatically by Jules for task [7467315040868261720](https://jules.google.com/task/7467315040868261720) started by @futurist-raghav*