### PR TITLE
🛡️ Sentinel: Fix path traversal in serveFile

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - [Path Traversal in serveFile]
+**Vulnerability:** The `serveFile` endpoint in `uploadController.ts` was vulnerable to path traversal because it joined `req.params.filename` directly to the uploads path without sanitization.
+**Learning:** `path.join` with unsanitized user input allows attackers to escape the intended directory using `../` sequences.
+**Prevention:** Always sanitize filenames from user input using `path.basename()` before using them in file system operations.

--- a/backend/src/controllers/uploadController.ts
+++ b/backend/src/controllers/uploadController.ts
@@ -219,7 +219,7 @@ export const uploadMultipleFiles = asyncHandler(async (req: AuthRequest, res: Re
 export const serveFile = asyncHandler(async (req: Request, res: Response): Promise<void> => {
   const { filename } = req.params;
   
-  if (!filename) {
+  if (!filename || typeof filename !== 'string') {
     res.status(400).json({
       success: false,
       message: 'Filename is required'
@@ -227,7 +227,9 @@ export const serveFile = asyncHandler(async (req: Request, res: Response): Promi
     return;
   }
 
-  const filePath = path.join(__dirname, '../../uploads', filename);
+  // Sanitize filename to prevent path traversal
+  const safeFilename = path.basename(filename);
+  const filePath = path.join(__dirname, '../../uploads', safeFilename);
 
   if (!fs.existsSync(filePath)) {
     res.status(404).json({


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Path traversal in `serveFile` endpoint.
🎯 Impact: Attackers could potentially read arbitrary files on the server by using `../` sequences in the filename parameter.
🔧 Fix: Sanitized `filename` using `path.basename()` to strip directory navigation components and added a type validation check to ensure it's a string.
✅ Verification: Verified using a Node.js one-liner to confirm `path.basename` behavior and performed manual code review. Unrelated lockfile changes were reverted.

---
*PR created automatically by Jules for task [1085020878828518459](https://jules.google.com/task/1085020878828518459) started by @futurist-raghav*