### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix mass assignment in report creation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-28 - [Mass Assignment Protection in Report Controller]
+**Vulnerability:** Mass assignment vulnerability in `createReport` where `req.body` was directly spread into the Prisma `create` call.
+**Learning:** Directly spreading user-controlled input (`req.body`) into database operations allows attackers to modify internal or administrative fields (like `status`, `adminNotes`, `reviewedById`) that should only be controlled by the system or administrators.
+**Prevention:** Always use an explicit whitelist of allowed fields when creating or updating records with user-provided data. Extract only the necessary properties from `req.body` before passing them to the database client.

--- a/backend/src/controllers/reportController.ts
+++ b/backend/src/controllers/reportController.ts
@@ -8,8 +8,30 @@ interface AuthRequest extends Request {
 
 export const createReport = asyncHandler(async (req: AuthRequest, res: Response): Promise<void> => {
   if (!req.user?.id) { res.status(401).json({ message: 'Not authenticated' }); return; }
+
+  const {
+    type,
+    description,
+    reason,
+    reportedUserId,
+    reportedPostId,
+    reportedCommentId,
+    reportedGroupId,
+    reportedJobId
+  } = req.body;
+
   const report = await prisma.report.create({
-    data: { ...req.body, reportedById: req.user.id }
+    data: {
+      type,
+      description,
+      reason,
+      reportedUserId,
+      reportedPostId,
+      reportedCommentId,
+      reportedGroupId,
+      reportedJobId,
+      reportedById: req.user.id
+    }
   });
   res.status(201).json({ success: true, data: report });
 });


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Mass Assignment
🎯 Impact: Attackers could potentially set administrative fields such as `status`, `adminNotes`, or `reviewedById` when creating a report.
🔧 Fix: Implemented an explicit whitelist of allowed fields from `req.body` in the `createReport` controller.
✅ Verification: Verified that the code passes linting and does not introduce new type errors in the affected function. Verified that only intended fields are passed to Prisma.

---
*PR created automatically by Jules for task [14979284111076001554](https://jules.google.com/task/14979284111076001554) started by @futurist-raghav*