### PR TITLE
🛡️ Sentinel: Fix Mass Assignment Vulnerability in User Profile Update

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - [Mass Assignment Protection in updateUserProfile]
+**Vulnerability:** Mass assignment vulnerability in the `updateProfile` function of `backend/src/controllers/userController.ts`. The implementation used the spread operator (`...req.body`) directly in the Prisma `update` call, allowing users to modify system-managed fields such as `role`, `status`, `isVerified`, and `hasPremiumBadge`.
+**Learning:** Even when validation middleware is present in routes, the controller itself should enforce strict whitelisting of fields to ensure defense in depth and prevent unintended side effects if route-level validation is bypassed or updated incorrectly.
+**Prevention:** Always use an explicit whitelist when processing user input for database updates. In Prisma, map only allowed keys from `req.body` to a clean `updateData` object before passing it to the database client.

--- a/backend/src/controllers/userController.ts
+++ b/backend/src/controllers/userController.ts
@@ -823,9 +823,29 @@ export const updateProfile = asyncHandler(async (req: AuthRequest, res: Response
     return;
   }
 
+  // Strictly whitelist fields to prevent mass assignment vulnerabilities
+  const allowedFields = [
+    'name', 'firstName', 'lastName', 'bio', 'headline', 'city', 'country',
+    'company', 'jobTitle', 'contactEmail', 'contactPhone', 'linkedInProfile',
+    'location', 'isAvailableAsMentor', 'experiences', 'educations', 'skills',
+    'interests', 'profileImage'
+  ];
+
+  const updateData: any = {};
+  for (const field of allowedFields) {
+    if (req.body[field] !== undefined) {
+      updateData[field] = req.body[field];
+    }
+  }
+
+  if (Object.keys(updateData).length === 0) {
+    res.status(400).json({ success: false, message: 'No valid fields provided for update' });
+    return;
+  }
+
   const profile = await prisma.user.update({
     where: { id },
-    data: { ...req.body }
+    data: updateData
   });
 
   res.status(200).json({ success: true, data: serializeUser(profile) });


### PR DESCRIPTION
This PR addresses a HIGH severity mass assignment vulnerability in the user profile update endpoint. By moving from an unsafe spread operator to a strict whitelist, we prevent unauthorized modification of sensitive user attributes like roles and verification status.

---
*PR created automatically by Jules for task [12980181689057846013](https://jules.google.com/task/12980181689057846013) started by @futurist-raghav*