### PR TITLE
🛡️ Sentinel: Fix mass assignment vulnerability in user profile update

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel Security Journal 🛡️
+
+## 2026-06-28 - [Mass Assignment Protection]
+**Vulnerability:** Mass assignment in user profile updates.
+**Learning:** Using `...req.body` (spread operator) in database updates allows users to modify internal or administrative fields (e.g., `role`, `status`, `isVerified`) if they are sent in the request body.
+**Prevention:** Always use an explicit whitelist of allowed fields when performing updates based on user-supplied input.

--- a/backend/src/controllers/userController.ts
+++ b/backend/src/controllers/userController.ts
@@ -823,9 +823,30 @@ export const updateProfile = asyncHandler(async (req: AuthRequest, res: Response
     return;
   }
 
+  // Use an explicit whitelist to prevent mass assignment vulnerabilities
+  const allowedFields = [
+    'name', 'firstName', 'lastName', 'bio', 'headline',
+    'city', 'country', 'company', 'jobTitle',
+    'contactEmail', 'contactPhone', 'linkedInProfile',
+    'location', 'isAvailableAsMentor', 'experiences',
+    'educations', 'skills', 'interests', 'profileImage'
+  ];
+
+  const updateData: any = {};
+  for (const field of allowedFields) {
+    if (req.body[field] !== undefined) {
+      updateData[field] = req.body[field];
+    }
+  }
+
+  if (Object.keys(updateData).length === 0) {
+    res.status(400).json({ success: false, message: 'No valid fields provided for update' });
+    return;
+  }
+
   const profile = await prisma.user.update({
     where: { id },
-    data: { ...req.body }
+    data: updateData
   });
 
   res.status(200).json({ success: true, data: serializeUser(profile) });


### PR DESCRIPTION
Fixed a mass assignment vulnerability in the user profile update endpoint by implementing an explicit whitelist of allowed fields. Also initialized the Sentinel Security Journal to track security-related findings.

---
*PR created automatically by Jules for task [6296010167263809298](https://jules.google.com/task/6296010167263809298) started by @futurist-raghav*